### PR TITLE
Add eslint-plugin-node

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
  - [Mocha](https://github.com/lo1tuma/eslint-plugin-mocha) - Linting rules for Mocha
  - [React](https://github.com/yannickcr/eslint-plugin-react) - Linting rules for React and JSX
  - [React Native](https://github.com/Intellicode/eslint-plugin-react-native) - React Native specific linting rules
+ - [Node](https://github.com/mysticatea/eslint-plugin-node) - Linting rules for Node.js (checking importing paths, ES syntax, ...)
 
 ### Misc.
 


### PR DESCRIPTION
There are rules:

- Prevent using unsupported syntaxes of ES6 and later.
- Prevent importing modules which don't exist in package.json.
- Prevent typo in importing paths.
- Prevent forgetting shebang for `"bin"` files.
