### PR TITLE
Add Shopify ESLint plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,9 +27,9 @@ If you want to contribute, please read the [contribution guidelines](contributin
  - [Canonical](https://github.com/gajus/eslint-config-canonical) – Shareable config for [Canonical style guide](https://github.com/gajus/canonical)
  - [ESLint](https://github.com/eslint/eslint/tree/master/packages/eslint-config-eslint) - Shareable config for ESLint's default settings
  - [Google](https://github.com/google/eslint-config-google) - Shareable config for the [Google style](http://google.github.io/styleguide/javascriptguide.xml)
+ - [Shopify](https://github.com/Shopify/javascript/tree/master/packages/eslint-plugin-shopify) - Shareable config for [Shopify's style guide](https://github.com/Shopify/javascript)
  - [Standard](https://github.com/feross/eslint-config-standard) - Shareable config for JavaScript [Standard Style](https://github.com/feross/standard)
  - [XO](https://github.com/sindresorhus/eslint-config-xo) - Shareable config for [XO](https://github.com/sindresorhus/xo)
- - [Shopify](https://github.com/Shopify/javascript/tree/master/packages/eslint-plugin-shopify) - Shareable config for [Shopify's style guide](https://github.com/Shopify/javascript)
 
 ## Parsers
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
  - [Google](https://github.com/google/eslint-config-google) - Shareable config for the [Google style](http://google.github.io/styleguide/javascriptguide.xml)
  - [Standard](https://github.com/feross/eslint-config-standard) - Shareable config for JavaScript [Standard Style](https://github.com/feross/standard)
  - [XO](https://github.com/sindresorhus/eslint-config-xo) - Shareable config for [XO](https://github.com/sindresorhus/xo)
+ - [Shopify](https://github.com/Shopify/javascript/tree/master/packages/eslint-plugin-shopify) - Shareable config for [Shopify's style guide](https://github.com/Shopify/javascript)
 
 ## Parsers
 


### PR DESCRIPTION
At Shopify, we've got a pretty nice [style guide](https://github.com/Shopify/javascript) and an associated [ESLint plugin](https://github.com/Shopify/javascript/tree/master/packages/eslint-plugin-shopify). Our plugin is one of the more comprehensive ones I've seen, with custom configurations for ES5/ ESNext/ React, as well as tool-specific configs for lodash, flow, jQuery, mocha/sinon/chai, and AVA. I think this makes it a good example for other companies to follow, but I totally understand if you are not interested in including it.