### PR TITLE
Remove `eslint-plugin-import-order`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,6 @@ If you want to contribute, please read the [contribution guidelines](contributin
 ### Style
 
  - [filenames](https://github.com/selaux/eslint-plugin-filenames) - Ensure consistent filenames for your javascript files
- - [import-order](https://github.com/jfmengels/eslint-plugin-import-order) - Enforce the order of import/require statements
  - [no-empty-blocks](https://github.com/alex-shnayder/eslint-plugin-no-empty-blocks) - Allows empty catch blocks, while disallowing other empty blocks
 
 ## Preconfigured Tools with ESLint Set up


### PR DESCRIPTION
Remove `eslint-plugin-import-order`.
I'm the maintainer of the repo, and have just deprecated the repo (see [here](https://github.com/jfmengels/eslint-plugin-import-order#deprecation-notice)).

For those interested in getting the same rules (or rather rule, singular), they have now been integrated and improved upon in @benmosher's `eslint-plugin-import`, which is already in the list.