### PR TITLE
Rename eslint-plugin-xo to eslint-plugin-unicorn

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Markdown](https://github.com/eslint/eslint-plugin-markdown) - Linting JavaScript in Markdown
 - [Node](https://github.com/mysticatea/eslint-plugin-node) - Linting rules for Node.js (checking importing paths, ES syntax, ...)
 - [TypeLint](https://github.com/yarax/typelint) - Introduces types, based on existing schemas (Swagger, Redux) and linting access to object properties, preventing `undefined` errors
-- [XO](https://github.com/sindresorhus/eslint-plugin-xo) - Various useful rules
+- [unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) - Various awesome ESLint rules
 
 ### Practices
 


### PR DESCRIPTION
https://github.com/sindresorhus/eslint-plugin-xo is now named https://github.com/sindresorhus/eslint-plugin-unicorn, this is just updating the name and url.
cc @sindresorhus