### PR TITLE
Add tool eslint-rule-documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [eslint-cli](https://github.com/mysticatea/eslint-cli) - This is the `eslint` command that executes a local installed ESLint.
 - [eslint-find-rules](https://github.com/sarbbottam/eslint-find-rules) - Find built-in ESLint rules you don't have in your custom config
 - [eslint-nibble](https://github.com/IanVS/eslint-nibble) - Ease into ESLint, by fixing one rule at a time
+- [eslint-rule-documentation](https://github.com/jfmengels/eslint-rule-documentation) - Find the url for the documentation of an ESLint rule
 - [eslint-watch](https://github.com/rizowski/eslint-watch) - Run ESLint with watch mode
 
 ## Tutorials


### PR DESCRIPTION
It is currently being used in eslint-find(rules, atom-linter-xo and atom-linter-eslint, and it shows users links (in the editor linter or console) to the documentation of the rule.

Just FYI, when I get requests to support plugins in the tool, I tell the contributor to also send a PR here. It might be nice to have it the other way around too, if it's not already supported in the tool ([list of supported plugins](https://github.com/jfmengels/eslint-rule-documentation/blob/master/plugins.json)).