### PR TITLE
Add eslint-plugin-eslint-comments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Node](https://github.com/mysticatea/eslint-plugin-node) - Linting rules for Node.js (checking importing paths, ES syntax, ...)
 - [TypeLint](https://github.com/yarax/typelint) - Introduces types, based on existing schemas (Swagger, Redux) and linting access to object properties, preventing `undefined` errors
 - [unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) - Various awesome ESLint rules
+- [ESLint Comments](https://github.com/mysticatea/eslint-plugin-eslint-comments) - Best practices about ESLint directive comments (`/*eslint-disable*/`, etc...)
 
 ### Practices
 


### PR DESCRIPTION
[eslint-plugin-eslint-comments](https://github.com/mysticatea/eslint-plugin-eslint-comments) is the rule set for the best practice about ESLint directive comments.
Mainly, this plugin suggests usage of the following comments:

- `/* eslint-disable */`
- `/* eslint-enable */`
- `// eslint-disable-line`
- `// eslint-disable-next-line`