### PR TITLE
Add es5 plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Babel](https://github.com/babel/eslint-plugin-babel) - Adds replacements for built-in rules to include Babel features
 - [Compat](https://github.com/amilajack/eslint-plugin-compat) - Lint browser compatability of APIs used ([caniuse](http://caniuse.com/#search=fetch) as an ESLint plugin)
 - [disable](https://github.com/mradionov/eslint-plugin-disable) - Disable specified plugins using file path patterns and inline comments
+- [es5](https://github.com/nkt/eslint-plugin-es5) - ESLint plugin for ES5 users (forbid ES2015+ usage)
 - [Flow](https://github.com/gajus/eslint-plugin-flowtype) - Flow type linting rules
 - [Flow Errors](https://github.com/amilajack/eslint-plugin-flowtype-errors) - Run Flow as an ESLint plugin
 - [GraphQL](https://github.com/apollostack/eslint-plugin-graphql) - Check your GraphQL query strings against a schema


### PR DESCRIPTION
Sometimes someone doesn't want or can't to use Babel. Even if you support modern browsers or node.js, JS engines have bugs like broken [block-scoping](http://stackoverflow.com/q/32665347). Maybe you only want to forbid usage of `for-of` in your project.

If this concerns you, this plugin should help you.