### PR TITLE
remove eslint-plugin-no-empty-blocks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,6 @@ If you want to contribute, please read the [contribution guidelines](contributin
 ### Style
 
 - [filenames](https://github.com/selaux/eslint-plugin-filenames) - Ensure consistent filenames for your javascript files
-- [no-empty-blocks](https://github.com/alex-shnayder/eslint-plugin-no-empty-blocks) - Allows empty catch blocks, while disallowing other empty blocks
 
 ## Preconfigured Tools with ESLint Set up
 


### PR DESCRIPTION
* eslint-plugin-no-empty-blocks is deprecated. 
* ESLint's native no-empty rule already supports the allowEmptyCatch option.