### PR TITLE
update eslint-cli URL.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 ## Tools
 
-- [eslint-cli](https://github.com/mysticatea/eslint-cli) - This is the `eslint` command that executes a local installed ESLint.
+- [eslint-cli](https://github.com/eslint/eslint-cli) - This is the `eslint` command that executes a local installed ESLint.
 - [eslint-find-rules](https://github.com/sarbbottam/eslint-find-rules) - Find built-in ESLint rules you don't have in your custom config
 - [eslint-index](https://github.com/wagerfield/eslint-index) - CLI for finding and managing rules in ESLint config files
 - [eslint-nibble](https://github.com/IanVS/eslint-nibble) - Ease into ESLint, by fixing one rule at a time


### PR DESCRIPTION
I have transferred `eslint-cli` repository to `eslint` org.
