### PR TITLE
add eslint-plugin-lodash-template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [JSDoc](https://github.com/gajus/eslint-plugin-jsdoc) - Linting rules for JSDoc comments
 - [Lodash](https://github.com/wix/eslint-plugin-lodash) - Lodash specific linting rules
 - [Lodash/fp](https://github.com/jfmengels/eslint-plugin-lodash-fp) - Lodash/fp specific linting rules
+- [Lodash template](https://github.com/ota-meshi/eslint-plugin-lodash-template) - Plugin for Lodash template/Underscore template
 - [Meteor](https://github.com/dferber90/eslint-plugin-meteor) - Meteor specific linting rules
 - [Mocha](https://github.com/lo1tuma/eslint-plugin-mocha) - Linting rules for Mocha
 - [Mongodb](https://github.com/nfroidure/eslint-plugin-mongodb) - Mongodb native nodejs driver linting rules


### PR DESCRIPTION
This PR adds `eslint-plugin-lodash-template` to the `Frameworks and Libraries` section.