### PR TITLE
Add Eslint-plugin-switch-case

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Promise](https://github.com/xjamundx/eslint-plugin-promise) - Best practices when working with promises.
 - [Security](https://github.com/nodesecurity/eslint-plugin-security) - ESLint rules for Node Security.
 - [Simple import sort](https://github.com/lydell/eslint-plugin-simple-import-sort) - Easy autofixable import sorting.
+- [Switch case](https://github.com/lukeapage/eslint-plugin-switch-case) Switch-case-specific linting rules for ESLint.
 - [this](https://github.com/matijs/eslint-plugin-this) - Write pure functions, don't allow `this`.
 - [XSS](https://github.com/Rantanen/eslint-plugin-xss) - Tries to detect XSS issues in codebase before they end up in production.
 

--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Promise](https://github.com/xjamundx/eslint-plugin-promise) - Best practices when working with promises.
 - [Security](https://github.com/nodesecurity/eslint-plugin-security) - ESLint rules for Node Security.
 - [Simple import sort](https://github.com/lydell/eslint-plugin-simple-import-sort) - Easy autofixable import sorting.
-- [Switch case](https://github.com/lukeapage/eslint-plugin-switch-case) Switch-case-specific linting rules for ESLint.
+- [Switch case](https://github.com/lukeapage/eslint-plugin-switch-case) - Switch-case-specific linting rules for ESLint.
 - [this](https://github.com/matijs/eslint-plugin-this) - Write pure functions, don't allow `this`.
 - [XSS](https://github.com/Rantanen/eslint-plugin-xss) - Tries to detect XSS issues in codebase before they end up in production.
 


### PR DESCRIPTION
Just recently came across this and it allows you to force a blank line after `break` and `return` in `switch` statements, which has made me very happy :)