### PR TITLE
Add eslint-plugin-json-format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [HTML](https://github.com/BenoitZugmeyer/eslint-plugin-html) - Linting for JavaScript inside of HTML `<script>` tags.
 - [import](https://github.com/benmosher/eslint-plugin-import) - Linting of ES2015+  import/export syntax, and prevent issues with misspelling of file paths and import names.
 - [JSON](https://github.com/azeemba/eslint-plugin-json) - Lint your JSON files.
+- [JSON, package.json](https://github.com/Bkucera/eslint-plugin-json-format) - Lint, format, and auto-fix your JSON files. Sort your `package.json`.
 - [Markdown](https://github.com/eslint/eslint-plugin-markdown) - Linting JavaScript in Markdown.
 - [Node](https://github.com/mysticatea/eslint-plugin-node) - Linting rules for Node.js (checking importing paths, ES syntax, ...).
 - [Notice](https://github.com/nickdeis/eslint-plugin-notice) - An eslint rule that checks the top of files and fixes them too!


### PR DESCRIPTION
This plugin has no large dependencies unlike `eslint-plugin-json`, and supports sorting `package.json` files

[`eslint-plugin-json-format`](https://github.com/Bkucera/eslint-plugin-json-format)