### PR TITLE
Replace Angular with AngularJS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 ### Frameworks and Libraries
 
-- [Angular](https://github.com/Gillespie59/eslint-plugin-angular) - Linting rules to adhere to the [John Papa's Angular Styleguide](https://github.com/johnpapa/angular-styleguide).
+- [AngularJS](https://github.com/Gillespie59/eslint-plugin-angular) - Linting rules to adhere to the [John Papa's AngularJS Styleguide](https://github.com/johnpapa/angular-styleguide).
 - [Backbone](https://github.com/ilyavolodin/eslint-plugin-backbone) - Linting rules for Backbone.
 - [Ember](https://github.com/netguru/eslint-plugin-ember) - Linting rules for Ember.
 - [GraphQL](https://github.com/apollostack/eslint-plugin-graphql) - Check your GraphQL query strings against a schema.


### PR DESCRIPTION
Angular V1 is called Angluar**JS** while Angular V2+ is just called Angular

https://en.wikipedia.org/wiki/Angular_(web_framework)