### PR TITLE
Add eslint-plugin-ecmascript-compat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [CSS-modules](https://github.com/atfzl/eslint-plugin-css-modules) - Lint undefined or unused rules for css modules.
 - [deprecate](https://github.com/AlexMost/eslint-plugin-deprecate) - Mark functions or modules as deprecated and get lint messages when they are used.
 - [disable](https://github.com/mradionov/eslint-plugin-disable) - Disable specified plugins using file path patterns and inline comments.
+- [ecmascript-compat](https://github.com/robatwilliams/es-compat) - Disable ECMAScript language features not supported by your browserslist targets.
 - [es](https://github.com/mysticatea/eslint-plugin-es) - Disable specific ECMAScript language versions or individual features.
 - [es5](https://github.com/nkt/eslint-plugin-es5) - ESLint plugin for ES5 users (forbid ES2015+ usage).
 - [Flow](https://github.com/gajus/eslint-plugin-flowtype) - Flow type linting rules.


### PR DESCRIPTION
This wraps the `es` plugin already on this list, selectively enabling its rules (plus a few others) based on MDN browser compatibility data for browser/runtime versions specified via browserslist.

It was to be called `eslint-plugin-es-compat`, but NPM rules on package name similarity didn't allow that. The repo name remains, because it also includes a CLI tool `check-es-compat`.

Disclosure: this is my own plugin. The readme explains why I think it's useful.