### PR TITLE
docs: add eslint-formatter-mo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [eslint-formatter-git-log](https://github.com/JamieMason/eslint-formatter-git-log) - ESLint Formatter featuring Git Author, Date, and Hash.
 - [eslint-formatter-github](https://github.com/hipstersmoothie/eslint-formatter-github) - See ESLint errors and warnings directly in pull requests.
 - [eslint-formatter-gitlab](https://gitlab.com/remcohaszing/eslint-formatter-gitlab) - Output ESLint results in the GitLab code quality results.
-- [eslint-formatter-mo](https://github.com/fengzilong/eslint-formatter-mo) - Good-lookin' ESLint formatter and also for delightful reading experience
+- [eslint-formatter-mo](https://github.com/fengzilong/eslint-formatter-mo) - Good-lookin' ESLint formatter and also for delightful reading experience.
 
 ## Preconfigured Tools with ESLint Set up
 

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [eslint-formatter-git-log](https://github.com/JamieMason/eslint-formatter-git-log) - ESLint Formatter featuring Git Author, Date, and Hash.
 - [eslint-formatter-github](https://github.com/hipstersmoothie/eslint-formatter-github) - See ESLint errors and warnings directly in pull requests.
 - [eslint-formatter-gitlab](https://gitlab.com/remcohaszing/eslint-formatter-gitlab) - Output ESLint results in the GitLab code quality results.
+- [eslint-formatter-mo](https://github.com/fengzilong/eslint-formatter-mo) - Good-lookin' ESLint formatter and also for delightful reading experience
 
 ## Preconfigured Tools with ESLint Set up
 


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/9125255/75581509-976f1f80-5aa4-11ea-8054-1877a89a154c.png" alt="snapshot" width="500px">

1. Code highlight
2. Good-looking maybe
3. Show eslint error/warning from the same line together makes a more delightful reading experience