### PR TITLE
Configs by type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,24 +25,32 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 ## Configs
 
-- [Adjunct](https://github.com/davidjbradshaw/eslint-config-adjunct) - A reasonable collection of plugins to use alongside your main esLint configuration.
+### Configs by Well-Known Companies/Organizations
+
 - [Airbnb](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) - Shareable config for [Airbnb's style guide](https://github.com/airbnb/javascript).
 - [Alloy](https://github.com/AlloyTeam/eslint-config-alloy) - Progressive ESLint config for your React/Vue/TypeScript projects.
-- [Ash-Nazg](https://github.com/brettz9/eslint-config-ash-nazg) - One config to rule them all!
-- [Canonical](https://github.com/gajus/eslint-config-canonical) - Shareable config for [Canonical style guide](https://github.com/gajus/canonical).
-- [Cecilia](https://github.com/SandroMiguel/eslint-config-cecilia) - ESLint configuration for awesome projects.
 - [ESLint](https://github.com/eslint/eslint/tree/master/packages/eslint-config-eslint) - Contains the ESLint configuration used for projects maintained by the ESLint team.
-- [ES](https://github.com/thenativeweb/eslint-config-es) - Shareable config for very strict code.
 - [Facebook](https://www.npmjs.com/package/eslint-config-fbjs) - Sharable config for Facebook's style guide.
 - [Google](https://github.com/google/eslint-config-google) - Shareable config for the [Google style](http://google.github.io/styleguide/javascriptguide.xml).
-- [Hardcore](https://github.com/EvgenyOrekhov/eslint-config-hardcore) - The most strict (but practical) ESLint config out there.
-- [Problems](https://github.com/RyanZim/eslint-config-problems) - Shareable config that only catches actual problems, and doesn't enforce stylistic preferences.
 - [React App](https://github.com/facebook/create-react-app/tree/master/packages/eslint-config-react-app) - Sharable config for [React](https://reactjs.org) projects.
 - [Shopify](https://github.com/Shopify/web-foundation/blob/master/packages/eslint-plugin/README.md) - Shareable config for [Shopify's style guide](https://github.com/Shopify/javascript).
-- [Standard](https://github.com/feross/eslint-config-standard) - Shareable config for JavaScript [Standard Style](https://github.com/feross/standard).
-- [Supermind](https://github.com/supermind/eslint-config-supermind) - Shareable config for Supermind style.
 - [Wikimedia](https://github.com/wikimedia/eslint-config-wikimedia) - Shareable config for [Wikimedia's style guide](https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript), used by [MediaWiki](https://www.mediawiki.org/).
+
+### Prominent Configs by Developers (100 stars or so)
+
+- [Canonical](https://github.com/gajus/eslint-config-canonical) - Shareable config for [Canonical style guide](https://github.com/gajus/canonical).
+- [Standard](https://github.com/feross/eslint-config-standard) - Shareable config for JavaScript [Standard Style](https://github.com/feross/standard).
 - [XO](https://github.com/xojs/eslint-config-xo) - Shareable config for [XO](https://github.com/xojs/xo).
+
+### Other Configs by Developers
+
+- [Adjunct](https://github.com/davidjbradshaw/eslint-config-adjunct) - A reasonable collection of plugins to use alongside your main esLint configuration.
+- [Ash-Nazg](https://github.com/brettz9/eslint-config-ash-nazg) - One config to rule them all!
+- [Cecilia](https://github.com/SandroMiguel/eslint-config-cecilia) - ESLint configuration for awesome projects.
+- [ES](https://github.com/thenativeweb/eslint-config-es) - Shareable config for very strict code.
+- [Hardcore](https://github.com/EvgenyOrekhov/eslint-config-hardcore) - The most strict (but practical) ESLint config out there.
+- [Problems](https://github.com/RyanZim/eslint-config-problems) - Shareable config that only catches actual problems, and doesn't enforce stylistic preferences.
+- [Supermind](https://github.com/supermind/eslint-config-supermind) - Shareable config for Supermind style.
 
 ## Globals
 


### PR DESCRIPTION
- Configs by Well-Known Companies and Organizations vs. Configs by Developers; closes #116

I added (Well-known) "Organizations", as I would think "Companies" may best also include the likes of Wikimedia's config or ESLint's own config.

I added "Well-known" for companies and organizations as there are some fairly unknown companies or smaller groups of developers who may put their project under an "organization" and I think including them would dilute the intent of having a separate list for companies/organizations (i.e., to find prominent configs). 

I put some fairly well-known ones in the Node community into a separate "pile" for "Prominent" Configs (100 stars or so), such as XO, as though they are not tied to a very prominent company or entity, they are still pretty popular. This would also better ensure that such configs could be found alongside the work of prominent individual developers without comparatively disadvantaging prominent developers because they didn't have an organization. I.e., the idea was to keep the "Companies/Well-known Organizations" pretty confined. But I'm happy to adjust of course as desired.