### PR TITLE
readme: add eslint-plugin-putout

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) - Various awesome ESLint rules.
 - [ESLint Comments](https://github.com/mysticatea/eslint-plugin-eslint-comments) - Best practices about ESLint directive comments (`/*eslint-disable*/`, etc.).
 - [eslint-plugin-eslint-plugin](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin) - An ESLint plugin for linting ESLint plugins.
+- [eslint-plugin-putout](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout) - an ESLint plugin integrates [putout](https://github.com/coderaiser/putout) linter into ESLint.
 
 ### Practices
 


### PR DESCRIPTION
Added link to [eslint-plugin-putout](https://github.com/coderaiser/putout/tree/master/packages/eslint-plugin-putout)  which integrates a powerful pluggable and configurable linter [putout](https://github.com/coderaiser/putout) into ESLint.