### PR TITLE
Added jest formatting plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Jasmine](https://github.com/tlvince/eslint-plugin-jasmine) - Linting rules for Jasmine.
 - Jest
   - [Enforcing practices](https://github.com/jest-community/eslint-plugin-jest) - Linting rules for Jest.
+  - [Enforcing consistent formatting](https://github.com/dangreenisrael/eslint-plugin-jest-formatting) - Formatting rules for Jest.
   - [Jest-async](https://www.npmjs.com/package/eslint-plugin-jest-async) - Async linting rule for Jest.
   - [Jest-DOM](https://github.com/testing-library/eslint-plugin-jest-dom) - Linting rules for Jest-DOM.
 - Mocha


### PR DESCRIPTION
This plugin provides the following formatting rules for jest. 

- padding-around-after-all-blocks
- padding-around-after-each-blocks
- padding-around-before-all-blocks
- padding-around-before-each-blocks
- padding-around-expect-groups
- padding-around-describe-blocks
- padding-around-test-blocks
- padding-around-all


Relevant links:
- https://github.com/jest-community/awesome-jest#linting
- https://www.npmjs.com/package/eslint-plugin-jest-formatting
- https://www.npmjs.com/package/eslint-plugin-jest#eslint-plugin-jest-formatting
