### PR TITLE
Add eslint-plugin-jsonc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - JSON
   - [JSON](https://github.com/azeemba/eslint-plugin-json) - Lint your JSON files.
   - [JSON, package.json](https://github.com/Bkucera/eslint-plugin-json-format) - Lint, format, and auto-fix your JSON files. Sort your `package.json`.
+  - [JSON with Comments](https://github.com/ota-meshi/eslint-plugin-jsonc) - ESLint plugin for JSON, JSONC and JSON5.
 - [Node](https://github.com/mysticatea/eslint-plugin-node) - Additional ESLint's rules for Node.js.
 - [SQL](https://github.com/gajus/eslint-plugin-sql) - SQL linting rules for ESLint.
 - [TypeScript](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin) - Linting rules for TypeScript.


### PR DESCRIPTION
This PR adds [eslint-plugin-jsonc](https://github.com/ota-meshi/eslint-plugin-jsonc).

The difference with eslint-plugin-json is that it uses AST just like eslint. You can also suppress warnings by comments.