### PR TITLE
Add eslint-config-airbnb-babel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 ### Configs by Well-Known Companies/Organizations
 
 - [Airbnb](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) - Shareable config for [Airbnb's style guide](https://github.com/airbnb/javascript).
+- [Airbnb-babel](https://github.com/davidjbradshaw/eslint-config-airbnb-babel) Airbnb's ESLint config with Babel Support.
 - [Airbnb-typescript](https://github.com/iamturns/eslint-config-airbnb-typescript) - Airbnb's ESLint config with TypeScript support.
 - [Alloy](https://github.com/AlloyTeam/eslint-config-alloy) - Progressive ESLint config for your React/Vue/TypeScript projects.
 - [ESLint](https://github.com/eslint/eslint/tree/master/packages/eslint-config-eslint) - Contains the ESLint configuration used for projects maintained by the ESLint team.

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 ### Configs by Well-Known Companies/Organizations
 
 - [Airbnb](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) - Shareable config for [Airbnb's style guide](https://github.com/airbnb/javascript).
-- [Airbnb-babel](https://github.com/davidjbradshaw/eslint-config-airbnb-babel) Airbnb's ESLint config with Babel Support.
+- [Airbnb-babel](https://github.com/davidjbradshaw/eslint-config-airbnb-babel) - Airbnb's ESLint config with Babel Support.
 - [Airbnb-typescript](https://github.com/iamturns/eslint-config-airbnb-typescript) - Airbnb's ESLint config with TypeScript support.
 - [Alloy](https://github.com/AlloyTeam/eslint-config-alloy) - Progressive ESLint config for your React/Vue/TypeScript projects.
 - [ESLint](https://github.com/eslint/eslint/tree/master/packages/eslint-config-eslint) - Contains the ESLint configuration used for projects maintained by the ESLint team.


### PR DESCRIPTION
Based on the same idea as airbnb-typescript, to work with eslint-plugin-babel.