### PR TITLE
adds `eslint-plugin-padding`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -217,6 +217,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [filenames](https://github.com/selaux/eslint-plugin-filenames) - Ensure consistent filenames for your JavaScript files.
 - [Simple import sort](https://github.com/lydell/eslint-plugin-simple-import-sort) - Easy autofixable import sorting.
 - [Switch case](https://github.com/lukeapage/eslint-plugin-switch-case) - Switch-case-specific linting rules for ESLint.
+- [padding](https://github.com/mu-io/eslint-plugin-padding) - Allows/disallows padding between statements.
 
 ### Testing Tools
 


### PR DESCRIPTION
Since `eslint` has decided to freeze stylistic rules, we've created `eslint-plugin-padding`. This plugin allows/disallows spacing between two given statements. This rule is a generalized version of the `eslint/padding-line-between-statements` rule and can also be used to replace `eslint/lines-between-class-members`.