### PR TITLE
Add `eslint-plugin-svelte3` in frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
   - [React Hooks](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks) - Linting rules for React Hooks.
   - [React Native](https://github.com/Intellicode/eslint-plugin-react-native) - React Native specific linting rules.
   - [React-Redux](https://github.com/DianaSuvorova/eslint-plugin-react-redux) - React-Redux specific linting rules.
+- [Svelte](https://github.com/sveltejs/eslint-plugin-svelte3) - Linting rules for Svelte v3 Components.
 - Vue
   - [VueJS](https://github.com/vuejs/eslint-plugin-vue) - Plugin for VueJS.
   - [VueJS Scoped CSS](https://github.com/future-architect/eslint-plugin-vue-scoped-css) - Plugin for Scoped CSS in VueJS.


### PR DESCRIPTION
Hi @dustinspecker!

Thank you for your work on this awesome list. It really helped me to find the plugins I needed to write more readable code in JavaScript. I noticed there's one plugin missing for the [Svelte](https://github.com/sveltejs/svelte) framework, so I immediately made a PR.

---

Svelte is becoming more popular as a JavaScript framework.
There's a plugin that is worth the attention for linting Components
written in Svelte version 3.
Without a doubt, it deserves a spot on awesome-eslint.