### PR TITLE
Add Lintier - CLI to quickly scaffold an ESLint & Prettier setup in a…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Tools](#tools)
 - [Developing for ESLint](#developing-for-eslint)
 - [Tutorials](#tutorials)
+- [Installation and Setup](#installation-and-setup)
 
 ## Configs
 
@@ -309,3 +310,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Linting React JSX with ESLint (in ES6)](https://egghead.io/lessons/react-linting-react-jsx-with-eslint-in-es6) - Video showing how to use React and JSX with ESLint.
 - [Plugin Module with Mixins](https://chrysanthium.com/eslint-integration) - Article on how to write a plugin as a node module containing modular mixin configuration.
 - [Writing a rule to spot undeclared props hiding in plain sight](http://blog.cowchimp.com/writing-a-custom-eslint-rule-to-spot-undeclared-props/) - Article about creating rules that require scope analysis.
+
+## Installation and Setup
+
+- [Lintier](https://github.com/josh-stillman/lintier) - CLI to quickly scaffold an ESLint & Prettier setup in a TypeScript project.


### PR DESCRIPTION
This PR proposes adding a link to Lintier, which is a CLI to automate setting up an ESLint & Prettier setup in a TypeScript project. Lintier provides options to install the airbnb styleguide, stylelint for linting styles, and lint-staged for linting pre-commit. Lintier installs the dependencies, creates the config files, and adds linting scripts to a project's package.json file.  Here's a gif:

![](https://github.com/josh-stillman/lintier/blob/main/lintier.gif?raw=true)

I also added a section for installation and setup for this bullet point.  It didn't seem to fit in with the other tools in the "tools" section.  

Thanks for your consideration!  Please let me know if you have any questions.
-Josh