### PR TITLE
Add `testcafe-community` & Edit `TestCafe`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,7 +256,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
   - [Enforcing practices](https://github.com/lo1tuma/eslint-plugin-mocha) - Linting rules for Mocha.
   - [Enforcing manageability](https://github.com/onechiporenko/eslint-plugin-mocha-cleanup/)
 - [QUnit](https://github.com/platinumazure/eslint-plugin-qunit) - Linting rules for QUnit.
-- [Testcafe](https://github.com/miherlosev/eslint-plugin-testcafe) - Linting rules for Testcafe.
+- [TestCafe-Community](https://github.com/testcafe-community/eslint-plugin-testcafe-community) - Linting rules for TestCafe with env globals.
 - [Testing Library](https://github.com/testing-library/eslint-plugin-testing-library) - Linting rules for Testing Library.
 
 ## Parsers
@@ -284,6 +284,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Restricted Globals](https://github.com/sidoshi/eslint-restricted-globals) - Expect `window` qualifier on globals that may otherwise be confusable as local variables.
 - [ES and browser globals](https://github.com/sindresorhus/globals) (originally from ESLint)
 - [chai globals](https://github.com/t-huth/eslint-plugin-chai-assert-bdd)
+- [TestCafe globals](https://github.com/miherlosev/eslint-plugin-testcafe) - `fixture` & `test` globals for TestCafe.
 
 ## Tools
 

--- a/readme.md
+++ b/readme.md
@@ -256,7 +256,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
   - [Enforcing practices](https://github.com/lo1tuma/eslint-plugin-mocha) - Linting rules for Mocha.
   - [Enforcing manageability](https://github.com/onechiporenko/eslint-plugin-mocha-cleanup/)
 - [QUnit](https://github.com/platinumazure/eslint-plugin-qunit) - Linting rules for QUnit.
-- [TestCafe-Community](https://github.com/testcafe-community/eslint-plugin-testcafe-community) - Fork of [Testcafe cafe](https://github.com/miherlosev/eslint-plugin-testcafe) for linting rules for TestCafe with env globals.
+- [TestCafe-Community](https://github.com/testcafe-community/eslint-plugin-testcafe-community) - TestCafe linting rules with env globals (fork from [TestCafe globals](https://github.com/miherlosev/eslint-plugin-testcafe)).
 - [Testing Library](https://github.com/testing-library/eslint-plugin-testing-library) - Linting rules for Testing Library.
 
 ## Parsers

--- a/readme.md
+++ b/readme.md
@@ -256,7 +256,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
   - [Enforcing practices](https://github.com/lo1tuma/eslint-plugin-mocha) - Linting rules for Mocha.
   - [Enforcing manageability](https://github.com/onechiporenko/eslint-plugin-mocha-cleanup/)
 - [QUnit](https://github.com/platinumazure/eslint-plugin-qunit) - Linting rules for QUnit.
-- [TestCafe-Community](https://github.com/testcafe-community/eslint-plugin-testcafe-community) - Linting rules for TestCafe with env globals.
+- [TestCafe-Community](https://github.com/testcafe-community/eslint-plugin-testcafe-community) - Fork of [Testcafe cafe](https://github.com/miherlosev/eslint-plugin-testcafe) for linting rules for TestCafe with env globals.
 - [Testing Library](https://github.com/testing-library/eslint-plugin-testing-library) - Linting rules for Testing Library.
 
 ## Parsers


### PR DESCRIPTION
Add the new testcafe-community plugin which is a fork from the original plugin with community gathered rules.  It extends the original plugin which only provided the global environment variables for TestCafe. The original has not seen an update since 2016 and is less prepared to support PRs for additional rules.  Therefore, I moved the original TestCafe down to the globals category since that is all it provides from the actual implementation `index.js`.

Thanks again for this awesome repo!