### PR TITLE
Add `eslint-remote-tester`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -301,6 +301,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
   plugin and rules with [Yeoman](http://yeoman.io/).
 - [editor-info](https://github.com/fisker/editor-info) - Detect whether one is within an editor/IDE and which type, allowing one to tweak ESLint configuration accordingly.
 - [eslint-dashboard](https://github.com/fengzilong/eslint-dashboard) - Interactive ESLint workflow that lives in your terminal.
+- [eslint-remote-tester](https://github.com/AriPerkkio/eslint-remote-tester) - CLI tool for testing given ESlint rules against multiple repositories at once.
 
 ## Developing for ESLint
 


### PR DESCRIPTION
Adds [`eslint-remote-tester`](https://github.com/AriPerkkio/eslint-remote-tester) to tools section