### PR TITLE
Add eslint-doc-generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -313,6 +313,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 ## Developing for ESLint
 
+- [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) - Generate documentation for your ESLint plugin including a rules table for your readme and header for your rule docs.
 - [eslint-docs](https://github.com/j-f1/eslint-docs) - Keep your rule descriptions up-to-date across the repository.
 
 ## Tutorials


### PR DESCRIPTION
I built this CLI tool [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) for automating the generation of the README rules list/table and rule doc title/notices for ESLint plugins. It follows common documentation conventions from top ESLint plugins and will help us standardize documentation across ESLint plugins (and generally improve the usability of custom rules through better documentation and streamline the process of adding new rules). I've tested or introduced it on 10+ of the top ESLint plugins.