### PR TITLE
fix: 404ing ESLint logo in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Awesome ESLint [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-[<img src="https://eslint.org/assets/img/logo.svg" width="160" align="right" alt="eslint">](http://eslint.org)
+[<img src="https://eslint.org/icon.svg" width="160" align="right" alt="eslint">](http://eslint.org)
 
 > A list of awesome ESLint configs, plugins, etc.
 


### PR DESCRIPTION
The README.md right now has an image not found.