### PR TITLE
fix: remove archived clean-regex link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -219,7 +219,6 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 ### Performance
 
-- [clean-regex](https://github.com/RunDevelopment/eslint-plugin-clean-regex) - JavaScript regex linter that aims to help write better regular expressions by pointing out errors and suggesting improvements.
 - [DOM](https://github.com/amilajack/eslint-plugin-dom)
 - [Optimize Regex](https://github.com/BrainMaestro/eslint-plugin-optimize-regex) - Optimize regex literals.
 - Perf-Standard [plugin](https://github.com/Raynos/eslint-plugin-perf-standard) and [Config](https://github.com/Raynos/eslint-config-perf-standard)


### PR DESCRIPTION
https://github.com/RunDevelopment/eslint-plugin-clean-regex is archived & deprecated. Its README.md points to https://github.com/ota-meshi/eslint-plugin-regexp now, which is already mentioned.