### PR TITLE
readme: add `paths` plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,7 +243,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [perfectionist sorting](https://github.com/azat-io/eslint-plugin-perfectionist) - Sort objects, imports, TypeScript types, enums, JSX props, etc.
 - [Switch case](https://github.com/lukeapage/eslint-plugin-switch-case) - Switch-case-specific linting rules for ESLint.
 - [padding](https://github.com/mu-io/eslint-plugin-padding) - Allows/disallows padding between statements.
-- [paths](https://github.com/vitonsky/eslint-plugin-paths) - Use paths from tsconfig/jsconfig and auto fix relative paths to aliases
+- [paths](https://github.com/vitonsky/eslint-plugin-paths) - Use paths from tsconfig/jsconfig and auto fix relative paths to aliases.
 
 ### Testing Tools
 

--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [perfectionist sorting](https://github.com/azat-io/eslint-plugin-perfectionist) - Sort objects, imports, TypeScript types, enums, JSX props, etc.
 - [Switch case](https://github.com/lukeapage/eslint-plugin-switch-case) - Switch-case-specific linting rules for ESLint.
 - [padding](https://github.com/mu-io/eslint-plugin-padding) - Allows/disallows padding between statements.
+- [paths](https://github.com/vitonsky/eslint-plugin-paths) - Use paths from tsconfig/jsconfig and auto fix relative paths to aliases
 
 ### Testing Tools
 


### PR DESCRIPTION
It is really annoying to manually fix a relative paths to aliases from tsconfig in project files, so i created a plugin to resolve a problem.
I hope it will save a time for another developers.