### PR TITLE
Add `eslint-plugin-exception-handling`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [ESLint Comments](https://github.com/mysticatea/eslint-plugin-eslint-comments) - Best practices about ESLint directive comments (`/*eslint-disable*/`, etc.).
 - [eslint-plugin-hexagonal-architecture](https://github.com/CodelyTV/eslint-plugin-hexagonal-architecture) - A plugin that helps you to enforce hexagonal architecture best practices.
 - [eslint-plugin-write-good-comments](https://github.com/kantord/eslint-plugin-write-good-comments) - Enforce good writing style in comments.
+- [eslint-plugin-exception-handling](https://github.com/Akronae/eslint-plugin-exception-handling) - Lints unhandled functions that might throw errors.
 - [fp](https://github.com/jfmengels/eslint-plugin-fp) - ESLint rules for functional programming.
 - [functional](https://github.com/jonaskello/eslint-plugin-functional) - ESLint rules to disable mutation and promote fp in JavaScript and TypeScript.
 - [Immutable](https://github.com/jhusain/eslint-plugin-immutable) - Disable all mutation in JavaScript.


### PR DESCRIPTION
Adding [eslint-plugin-exception-handling](https://github.com/Akronae/eslint-plugin-exception-handling), a plugin I created after failing to find a satisfying way to get warned about possibly unhandled errors.  
