### PR TITLE
Add `eslint-plugin-rule-adoption`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -311,6 +311,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [eslint-interactive](https://github.com/mizdra/eslint-interactive) - The CLI tool to fix huge number of ESLint errors.
 - [eslint-multiplexer](https://github.com/pimlie/eslint-multiplexer) - Multiplex eslint results and merge results for common files.
 - [eslint-nibble](https://github.com/IanVS/eslint-nibble) - Ease into ESLint, by fixing one rule at a time.
+- [eslint-plugin-rule-adoption](https://github.com/Jugbot/eslint-plugin-rule-adoption) - An eslint plugin for incremental rule adoption, when `--fix` and codemods don't cut it.
 - [eslint-rule-documentation](https://github.com/jfmengels/eslint-rule-documentation) - Find the url for the documentation of an ESLint rule.
 - [eslint-watch](https://github.com/rizowski/eslint-watch) - Run ESLint with watch mode.
 - [codacy-eslint](https://github.com/codacy/codacy-eslint) - Docker used at [Codacy](https://www.codacy.com) to run ESLint.


### PR DESCRIPTION
This is a plugin I made. I didn't see any rules around popularity requirements, so I'm wondering if could use this list to advertise?

Full description is available in the package repo.
https://github.com/Jugbot/eslint-plugin-rule-adoption