### PR TITLE
Update description of eslint-plugin-import and eslint-plugin-import-x

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,8 +206,8 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [fp](https://github.com/jfmengels/eslint-plugin-fp) - ESLint rules for functional programming.
 - [functional](https://github.com/jonaskello/eslint-plugin-functional) - ESLint rules to disable mutation and promote fp in JavaScript and TypeScript.
 - [Immutable](https://github.com/jhusain/eslint-plugin-immutable) - Disable all mutation in JavaScript.
-- [import](https://github.com/benmosher/eslint-plugin-import) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names. Still does not work with ESlint 9 and does not support flat configs.
-- [import-x](https://github.com/un-ts/eslint-plugin-import-x) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names. Properly maintained lightweight fork of `eslint-plugin-import` with the proper support of latest ESlint.
+- [import](https://github.com/benmosher/eslint-plugin-import) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names.
+- [import-x](https://github.com/un-ts/eslint-plugin-import-x) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names. Lightweight fork of `eslint-plugin-import`, but which breaks backwards compatibility. 
 - [new-with-error](https://github.com/Trott/eslint-plugin-new-with-error) - Require errors to be thrown using `new`.
 <!-- lint ignore awesome-spell-check -->
 - [no-argument-spread](https://github.com/causalhq/eslint-plugin-no-argument-spread) - Lints against expressions like `Math.max(...args)` that can lead to a stack overflow for large arrays.


### PR DESCRIPTION
`eslint-plugin-import` now supports both flat config (v2.30.0) and ESLint 9 (v2.31.0) (https://github.com/import-js/eslint-plugin-import/releases), so I removed the sentences that say it doesn't.

Removed "properly maintained" from the description of `eslint-plugin-import-x`, which is just passive aggressive language from someone unhappy with the way `eslint-plugin-import` is maintained, and added that `eslint-plugin-import-x` drops backwards compatibility, which is one of the main reasons for this fork (see https://github.com/un-ts/eslint-plugin-import-x/issues/24). 
