### PR TITLE
Add @gitbutler/no-relative-imports

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,6 +252,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Switch case](https://github.com/lukeapage/eslint-plugin-switch-case) - Switch-case-specific linting rules for ESLint.
 - [padding](https://github.com/mu-io/eslint-plugin-padding) - Allows/disallows padding between statements.
 - [paths](https://github.com/vitonsky/eslint-plugin-paths) - Use paths from tsconfig/jsconfig and auto fix relative paths to aliases.
+- [@gitbutler/no-relative-imports](https://www.npmjs.com/package/@gitbutler/no-relative-imports) - Use paths from tsconfig and auto fix relative paths to aliases. Observes tsconfig inheritance.
 
 ### Testing Tools
 


### PR DESCRIPTION
@gitbuter/no-relative-imports is an eslint plugin that provides warnings if there is a relative import that could be re-written using an alias provided in your tsconfig.json paths. We ended up writing this plugin because we needed to also consider tsconfig inheritance (the `extends`) property, and thought it would be helpful to share.