### PR TITLE
Add eslint-plugin-error-cause

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,6 +195,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [arrow functions](https://github.com/getify/eslint-plugin-proper-arrows) - ESLint rules to ensure proper arrow function definitions.
 - [boundaries](https://github.com/javierbrea/eslint-plugin-boundaries) - Ensures that your architecture boundaries are respected by the elements in your project checking file structure and dependencies.
 - [@eslint-community/eslint-plugin-eslint-comments](https://github.com/eslint-community/eslint-plugin-eslint-comments) - Best practices about ESLint directive comments (`/*eslint-disable*/`, etc.). Properly maintained fork of no longer maintained `eslint-plugin-eslint-comments`.
+- [eslint-plugin-error-cause](https://github.com/Amnish04/eslint-plugin-error-cause) - A plugin to preserve original error context when re-throwing exceptions.
 - [eslint-plugin-hexagonal-architecture](https://github.com/CodelyTV/eslint-plugin-hexagonal-architecture) - A plugin that helps you to enforce hexagonal architecture best practices.
 - [eslint-plugin-write-good-comments](https://github.com/kantord/eslint-plugin-write-good-comments) - Enforce good writing style in comments.
 - [eslint-plugin-exception-handling](https://github.com/Akronae/eslint-plugin-exception-handling) - Lints unhandled functions that might throw errors.


### PR DESCRIPTION
I recently wrote an ESLint plugin to prevent losing original error context when throwing new exceptions.

It flags all the instances of unused `cause` property when an original cause error is available in scope like so:

```ts
try {
    // This might throw an error with important details of failure
    fetch("some resource");
} catch (error) {
    throw new Error("Failed to perform some high level operation", {
        // Not using this would mean losing important error context
       // that might have been valuable during debugging.
        cause: error,
    });
}
```

Here's my blog post with more info:
https://dev.to/amnish04/never-lose-valuable-error-context-in-javascript-3aco

