### PR TITLE
Add `eslint-disable-autofix`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -324,6 +324,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [editor-info](https://github.com/fisker/editor-info) - Detect whether one is within an editor/IDE and which type, allowing one to tweak ESLint configuration accordingly.
 - [eslint-dashboard](https://github.com/fengzilong/eslint-dashboard) - Interactive ESLint workflow that lives in your terminal.
 - [eslint-remote-tester](https://github.com/AriPerkkio/eslint-remote-tester) - CLI tool for testing given ESlint rules against multiple repositories at once.
+- [eslint-disable-autofix](https://github.com/MorevM/eslint-disable-autofix/) - Utility to disable autofix for specific ESLint rules.
 
 ## Developing for ESLint
 


### PR DESCRIPTION
This information is also available in the [repository's README](http://github.com/morevm/eslint-disable-autofix/), but I'll highlight the key points here.

This utility lets you disable autofix for both ESLint core rules and third-party plugins in cases where autofix is either undesirable or not working correctly.

It's a temporary workaround - there's an [open RFC](https://github.com/eslint/rfcs/pull/134) to ESLint core (which I authored), and I hope the feature will be added to ESLint in the coming months. However, the process takes time, and the problem exists today. This utility is meant to help in the meantime.

Once we agree on a public API in the RFC, I also plan to support the proposed format here before it becomes available in ESLint itself. That way, this utility will serve as a full polyfill, making the eventual migration easier for those who need it.

I'll remove this utility from the list once the feature is available in ESLint core - though it may still be useful for a while, until the new version is widely adopted.