### PR TITLE
add eslint-plugin-signature-design

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [@eslint-community/eslint-plugin-eslint-comments](https://github.com/eslint-community/eslint-plugin-eslint-comments) - Best practices about ESLint directive comments (`/*eslint-disable*/`, etc.). Properly maintained fork of no longer maintained `eslint-plugin-eslint-comments`.
 - [eslint-plugin-error-cause](https://github.com/Amnish04/eslint-plugin-error-cause) - A plugin to preserve original error context when re-throwing exceptions.
 - [eslint-plugin-hexagonal-architecture](https://github.com/CodelyTV/eslint-plugin-hexagonal-architecture) - A plugin that helps you to enforce hexagonal architecture best practices.
+- [eslint-plugin-signature-design](https://github.com/Vladyslav-Soldatenko/eslint-plugin-signature-design) - Forbids functions with too many parameters of the same type, encouraging object-based signatures and preventing primitive obsession. 
 - [eslint-plugin-write-good-comments](https://github.com/kantord/eslint-plugin-write-good-comments) - Enforce good writing style in comments.
 - [eslint-plugin-exception-handling](https://github.com/Akronae/eslint-plugin-exception-handling) - Lints unhandled functions that might throw errors.
 - [fp](https://github.com/jfmengels/eslint-plugin-fp) - ESLint rules for functional programming.


### PR DESCRIPTION
I recently wrote a plugin to prevent multiple (number is configurable) parameters of the same type. For example:
`function confusingFoo(a: string, b: string, c: string) {}`
 this is considered bad, because you can very easily confuse the order of parameters. And you have to open the function signature to double check, TypeScript won't help you

However,
`function maintainableFoo(args: { a: string, b: string, c: string }) {} `
This is much better, because you can easily see, what value you pass to each parameter. This works both with multiple primitive arguments as well as multiple complex-type parameters (as long as they are the same)

`function uniqueParams(a: string, b: number, c: boolean) {}`
 Is allowed, of course