### PR TITLE
Add `eslint-plugin-mutate` plugin to the "Practices" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [eslint-plugin-exception-handling](https://github.com/Akronae/eslint-plugin-exception-handling) - Lints unhandled functions that might throw errors.
 - [fp](https://github.com/jfmengels/eslint-plugin-fp) - ESLint rules for functional programming.
 - [functional](https://github.com/jonaskello/eslint-plugin-functional) - ESLint rules to disable mutation and promote fp in JavaScript and TypeScript.
+- [mutate](https://github.com/gchumillas/eslint-plugin-mutate) - Prevent accidental parameter mutations by enforcing explicit `mut` prefix (JavaScript) or `Mut<T>` type annotation (TypeScript).
 - [Immutable](https://github.com/jhusain/eslint-plugin-immutable) - Disable all mutation in JavaScript.
 - [import](https://github.com/benmosher/eslint-plugin-import) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names.
 - [import-x](https://github.com/un-ts/eslint-plugin-import-x) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names. Lightweight fork of `eslint-plugin-import`, but which breaks backwards compatibility.


### PR DESCRIPTION
This plugin prevent accidental parameter mutations by enforcing explicit `mut` prefix (JavaScript) or `Mut<T>` type annotation (TypeScript). For example:

```ts
// ⚠️ `items` is mutated in origin (use `numItems` in JavaScript)
function doSomething(items: Mut<[]number>) {
   const firstItem = items.shift()
   console.log(firstItem) // prints 1
}

// ⚠️ `items` can be mutated (use `numItems` in JavaScript)
const items: Mut<[]number> = [1, 2, 3];
doSomething(items)
console.log(items) // prints [2, 3] !!!
```

These are the available rules:
```js
module.exports = {
  plugins: ['mutate'],
  rules: {
    'mutate/require-mut-param': 'error',  // Check parameters within functions
    'mutate/require-mut-var': 'error'     // Check variables passed to functions
  }
};
```