### PR TITLE
Add eslint-plugin-sumerish

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [ReDoSDetector](https://github.com/tjenkinson/eslint-plugin-redos-detector) - ESLint plugin for finding possible ReDoS vulnerabilities.
 - [RegExp](https://github.com/ota-meshi/eslint-plugin-regexp) - ESLint plugin for finding regexp mistakes and style guide violations.
 - [sort-keys-fix](https://github.com/leo-buneev/eslint-plugin-sort-keys-fix) - Adds fixer for ESLint `sort-keys` rule.
+- [sumerish](https://github.com/robis24/sumerish-vscode/tree/main/eslint-plugin-sumerish) - Enforces - Sumerish naming conventions and type contracts on JS/TS identifiers.
 - [this](https://github.com/matijs/eslint-plugin-this) - Write pure functions, don't allow `this`.
 - [toplevel](https://github.com/HKalbasi/eslint-plugin-toplevel) - An eslint plugin for disallow side effect at module toplevel.
 


### PR DESCRIPTION
ESLint plugin that enforces Sumerish naming conventions and type contracts on JS/TS identifiers.

- Validates suffix chain slot order (e.g. -en before -is)
- Enforces type contracts implied by suffixes (-is → boolean, -will → Promise, etc.)

npm: https://www.npmjs.com/package/eslint-plugin-sumerish