### PR TITLE
Add eslint-plugin-ime-safe-form

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [fp](https://github.com/jfmengels/eslint-plugin-fp) - ESLint rules for functional programming.
 - [functional](https://github.com/jonaskello/eslint-plugin-functional) - ESLint rules to disable mutation and promote fp in JavaScript and TypeScript.
 - [mutate](https://github.com/gchumillas/eslint-plugin-mutate) - Prevent accidental parameter mutations by enforcing explicit `mut` prefix (JavaScript) or `Mut<T>` type annotation (TypeScript).
+- [ime-safe-form](https://github.com/hiroya-uga/eslint-plugin-ime-safe-form) - Prevents accidental form submission during IME composition by requiring `e.isComposing` guard or form `submit` event.
 - [Immutable](https://github.com/jhusain/eslint-plugin-immutable) - Disable all mutation in JavaScript.
 - [import](https://github.com/benmosher/eslint-plugin-import) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names.
 - [import-x](https://github.com/un-ts/eslint-plugin-import-x) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names. Lightweight fork of `eslint-plugin-import`, but which breaks backwards compatibility.


### PR DESCRIPTION
## eslint-plugin-ime-safe-form

https://www.npmjs.com/package/eslint-plugin-ime-safe-form

I wrote a plugin to prevent accidental form submission during IME composition.

When a `keydown` handler checks for the Enter key like this:

```js
input.addEventListener('keydown', (e) => {
  if (e.key === 'Enter') submit();
});
```

users typing with an IME (Input Method Editor) — will accidentally submit the form mid-input. Pressing Enter to confirm an IME candidate fires `keydown` before `compositionend`, so the form submits before they finish typing.

The fix is either an `e.isComposing` guard:

```js
input.addEventListener('keydown', (e) => {
  if (e.isComposing) return;
  if (e.key === 'Enter') submit();
});
```

or using the form's `submit` event, which fires only after composition completes.

The plugin also prohibits `keypress`, which is deprecated.

Supports `addEventListener`, `onkeydown`/`onkeyup` assignment, and JSX `onKeyDown`/`onKeyUp` props.
