### PR TITLE
Add @typpi/eslint-plugin-vite

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 ### Frameworks
 
+- [@typpi/eslint-plugin-vite](https://github.com/Nick2bad4u/eslint-plugin-vite) - ESLint rules for Vite, Vitest, and Vitest bench projects.
 - [Angular](https://github.com/angular-eslint/angular-eslint) - Linting rules for Angular (v2+).
 - [AngularJS](https://github.com/Gillespie59/eslint-plugin-angular) - Linting rules to adhere to the [John Papa's AngularJS Styleguide](https://github.com/johnpapa/angular-styleguide).
 - [Astro](https://github.com/ota-meshi/eslint-plugin-astro) - Plugin for [Astro components](https://docs.astro.build/en/core-concepts/astro-components/).


### PR DESCRIPTION
Adds @typpi/eslint-plugin-vite to the relevant section.

Repository: https://github.com/Nick2bad4u/eslint-plugin-vite

Validation:
- `npx awesome-lint readme.md`