### PR TITLE
Add eslint-plugin-tsdoc-require-2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [TypeScript](https://typescript-eslint.io) - Linting rules for TypeScript.
   - [eslint-plugin-erasable-syntax-only](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only) - Granularly enforces TypeScript's erasableSyntaxOnly flag.
   - [eslint-plugin-expect-type](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type) - Provides Twoslash, $ExpectError, and $ExpectType type assertions.
+  - [eslint-plugin-tsdoc-require-2](https://github.com/Nick2bad4u/eslint-plugin-tsdoc-require-2) - Require TSDoc comments for exported TypeScript declarations.
 - [YAML](https://github.com/ota-meshi/eslint-plugin-yml) - ESLint plugin for YAML.
 
 ### Libraries


### PR DESCRIPTION
Adds eslint-plugin-tsdoc-require-2 to the relevant section.

Repository: https://github.com/Nick2bad4u/eslint-plugin-tsdoc-require-2

Validation:
- `npx awesome-lint readme.md`