### PR TITLE
Add eslint-plugin-typefest

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [TypeScript](https://typescript-eslint.io) - Linting rules for TypeScript.
   - [eslint-plugin-erasable-syntax-only](https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only) - Granularly enforces TypeScript's erasableSyntaxOnly flag.
   - [eslint-plugin-expect-type](https://github.com/JoshuaKGoldberg/eslint-plugin-expect-type) - Provides Twoslash, $ExpectError, and $ExpectType type assertions.
+  - [eslint-plugin-typefest](https://github.com/Nick2bad4u/eslint-plugin-typefest) - ESLint rules for adopting type-fest and ts-extras conventions.
 - [YAML](https://github.com/ota-meshi/eslint-plugin-yml) - ESLint plugin for YAML.
 
 ### Libraries


### PR DESCRIPTION
Adds eslint-plugin-typefest to the relevant section.

Repository: https://github.com/Nick2bad4u/eslint-plugin-typefest

Validation:
- `npx awesome-lint readme.md`