### PR TITLE
Add eslint-plugin-copilot

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 ### Misc
 
+- [eslint-plugin-copilot](https://github.com/Nick2bad4u/eslint-plugin-copilot) - ESLint rules for GitHub Copilot repository customization files.
 - [Diff](https://github.com/paleite/eslint-plugin-diff) - Run ESLint on your changed lines only. Also supports CI!
 - [Misc](https://github.com/ilyub/eslint-plugin-misc) - Miscellaneous rules including rules for creating custom checks and wrapping (modifying) third-party rules.
 - [Notice](https://github.com/nickdeis/eslint-plugin-notice) - An eslint rule that checks the top of files and fixes them too!


### PR DESCRIPTION
Adds eslint-plugin-copilot to the relevant section.

Repository: https://github.com/Nick2bad4u/eslint-plugin-copilot

Validation:
- `npx awesome-lint readme.md`