### PR TITLE
Add Internationalization category with i18next and i18n-leak

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
   - [Deprecation](#deprecation)
   - [Embedded](#embedded)
   - [Frameworks](#frameworks)
+  - [Internationalization](#internationalization)
   - [Languages and Environments](#languages-and-environments)
   - [Libraries](#libraries)
   - [Misc](#misc)
@@ -141,6 +142,11 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - Vue
   - [VueJS](https://github.com/vuejs/eslint-plugin-vue) - Plugin for VueJS.
   - [VueJS Scoped CSS](https://github.com/future-architect/eslint-plugin-vue-scoped-css) - Plugin for Scoped CSS in VueJS.
+
+### Internationalization
+
+- [I18n Leak](https://github.com/Sloppy0726/eslint-plugin-i18n-leak) - Finds i18n bugs with no string literal to scan: form constraints whose validation message the browser renders in its own locale, and raw `error.message` text reaching the user.
+- [i18next](https://github.com/edvardchen/eslint-plugin-i18next) - Finds untranslated string literals in source, with `markupOnly` and `jsx-only` modes to narrow the scan.
 
 ### Languages and Environments
 


### PR DESCRIPTION
Adds an **Internationalization** category under Plugins, with two entries.

The list has no i18n category today, and no i18n plugin listed anywhere — `eslint-plugin-i18next` is the established one in this space and wasn't on the list, so I've added it alongside mine rather than on its own, since a category with one entry isn't a category.

The two plugins do different jobs, which is why both are worth listing:

- **i18next** scans source for untranslated string literals. That's the well-known half of the problem.
- **i18n-leak** covers the half with no literal to scan. `<input required>` inside a `<form>` hands the validation message to the browser, which renders it from `navigator.language` — so a fully translated form still says "Please fill out this field." in the wrong language, and the offending string is in Chrome, not your repo. Same for `error.message` reaching the screen: raw backend text, untranslated, sometimes leaking internals.

Placed between Frameworks and Languages and Environments to keep the section order alphabetical, and entries are alphabetical within the section.

Disclosure: I wrote i18n-leak. Happy to drop it and land the i18next entry plus the category on its own if you'd rather — the list is missing i18n either way.
