### PR TITLE
Add eslint-plugin-typeorm-enterprise

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,6 +247,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [pii](https://github.com/shiva-hack/eslint-plugin-pii) - Checks and enforces PII Compliance of the code. i.e. no email address, birth date, IP address or phone number in comments or string literals.
 - [pg](https://github.com/interlace-collie/eslint/tree/main/packages/eslint-plugin-pg) - PostgreSQL/node-postgres security: SQL injection prevention (CWE-89), connection pool leak detection (CWE-772), transaction safety. 13 rules with CWE mapping.
 - [Security](https://github.com/nodesecurity/eslint-plugin-security) - ESLint rules for Node Security.
+- [typeorm-enterprise](https://github.com/alokraj68/eslint-plugin-typeorm-enterprise) - TypeORM security and governance: SQL injection prevention, transaction safety, and multi-tenant query guards.
 - [xss](https://github.com/Rantanen/eslint-plugin-xss) - Tries to detect XSS issues in codebase before they end up in production.
 
 ### Style


### PR DESCRIPTION
Adds eslint-plugin-typeorm-enterprise to the Plugins section.

It provides TypeORM-specific rules that catch unsafe database access at lint
time: raw SQL, interpolated SQL (injection), synchronise: true, EntityManager
raw queries, unsafe QueryBuilder deletes, missing transactions, multi-tenant
scoping, and count-vs-exists. AST-only (works in any ESLint 9 flat config),
also runs under oxlint, with an optional type-aware mode.

npm: https://www.npmjs.com/package/eslint-plugin-typeorm-enterprise