### PR TITLE
Add import-boundary to Practices

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,6 +214,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [Immutable](https://github.com/jhusain/eslint-plugin-immutable) - Disable all mutation in JavaScript.
 - [import](https://github.com/benmosher/eslint-plugin-import) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names.
 - [import-x](https://github.com/un-ts/eslint-plugin-import-x) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names. Lightweight fork of `eslint-plugin-import`, but which breaks backwards compatibility.
+- [import-boundary](https://github.com/nayounsang/eslint-plugin-import-boundary) - Enforces import boundaries from directory nesting: only a parent may import a direct child's public entry (`index`), with `rootFiles` / `sharedFiles` escapes.
 - [logical-imports](https://gitlab.com/philbooth/eslint-plugin-logical-imports) - Sort imports logically by local name.
 - [Math](https://github.com/ota-meshi/eslint-plugin-math) - ESLint plugin related to Math object and Number.
 - [new-with-error](https://github.com/Trott/eslint-plugin-new-with-error) - Require errors to be thrown using `new`.


### PR DESCRIPTION
## Add import-boundary

Adds [eslint-plugin-import-boundary](https://github.com/nayounsang/eslint-plugin-import-boundary) under **Plugins → Practices and Specific ES Features**, next to `boundaries` / `import`.

It turns directory nesting into import boundaries. Unlike `boundaries` (element-type rules), this derives boundaries from **directory structure**.

- Docs: https://nayounsang.github.io/eslint-plugin-import-boundary/
- npm: https://www.npmjs.com/package/eslint-plugin-import-boundary
- github: https://github.com/nayounsang/eslint-plugin-import-boundary
