### PR TITLE
Fix pg plugin link (repo moved)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,7 +245,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [no-secrets](https://github.com/nickdeis/eslint-plugin-no-secrets) - An eslint plugin that detects potential secrets/credentials.
 - [no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) - Checks for `innerHTML`, `outerHTML`, etc.
 - [pii](https://github.com/shiva-hack/eslint-plugin-pii) - Checks and enforces PII Compliance of the code. i.e. no email address, birth date, IP address or phone number in comments or string literals.
-- [pg](https://github.com/interlace-collie/eslint/tree/main/packages/eslint-plugin-pg) - PostgreSQL/node-postgres security: SQL injection prevention (CWE-89), connection pool leak detection (CWE-772), transaction safety. 13 rules with CWE mapping.
+- [pg](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-pg) - PostgreSQL/node-postgres security: SQL injection prevention (CWE-89), connection pool leak detection (CWE-772), transaction safety. 13 rules with CWE mapping.
 - [Security](https://github.com/nodesecurity/eslint-plugin-security) - ESLint rules for Node Security.
 - [xss](https://github.com/Rantanen/eslint-plugin-xss) - Tries to detect XSS issues in codebase before they end up in production.
 


### PR DESCRIPTION
The `pg` entry in the Security section links to `github.com/interlace-collie/eslint`, which 404s since the org was renamed. Updated it to the current home at `ofri-peretz/eslint`.

I added that entry in #253 — the rename is mine, sorry for the churn.
