### PR TITLE
Add eslint-plugin-import-next to Practices and Specific ES Features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [ime-safe-form](https://github.com/hiroya-uga/eslint-plugin-ime-safe-form) - Prevents accidental form submission during IME composition by requiring `e.isComposing` guard or form `submit` event.
 - [Immutable](https://github.com/jhusain/eslint-plugin-immutable) - Disable all mutation in JavaScript.
 - [import](https://github.com/benmosher/eslint-plugin-import) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names.
+- [import-next](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-import-next) - Drop-in replacement for `eslint-plugin-import` with a rewritten cycle detector and no config changes required.
 - [import-x](https://github.com/un-ts/eslint-plugin-import-x) - Linting of ES2015+ import/export syntax, and prevent issues with misspelling of file paths and import names. Lightweight fork of `eslint-plugin-import`, but which breaks backwards compatibility.
 - [logical-imports](https://gitlab.com/philbooth/eslint-plugin-logical-imports) - Sort imports logically by local name.
 - [Math](https://github.com/ota-meshi/eslint-plugin-math) - ESLint plugin related to Math object and Number.


### PR DESCRIPTION
Adds `eslint-plugin-import-next` alongside the existing `import` and `import-x` entries, in alphabetical order. Passes `npx awesome-lint`.
