### PR TITLE
Add eslint-plugin-no-spanish to Misc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 - [Diff](https://github.com/paleite/eslint-plugin-diff) - Run ESLint on your changed lines only. Also supports CI!
 - [Misc](https://github.com/ilyub/eslint-plugin-misc) - Miscellaneous rules including rules for creating custom checks and wrapping (modifying) third-party rules.
-- [no-spanish](https://github.com/Nicolasramos411/eslint-plugin-no-spanish) - Flags Spanish comments and Spanish variable/function/class names to keep a JS/TS codebase in English.
+- [no-spanish](https://github.com/Nicolasramos411/eslint-plugin-no-spanish) - Flags Spanish comments and Spanish variable/function/class names to keep language usage consistent in a JS/TS codebase.
 - [Notice](https://github.com/nickdeis/eslint-plugin-notice) - An eslint rule that checks the top of files and fixes them too!
 - [Only-Error](https://github.com/davidjbradshaw/eslint-plugin-only-error) - Convert all rules to errors.
 - [Only-Warn](https://github.com/bfanger/eslint-plugin-only-warn) - Convert all rules to warnings.

--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 - [Diff](https://github.com/paleite/eslint-plugin-diff) - Run ESLint on your changed lines only. Also supports CI!
 - [Misc](https://github.com/ilyub/eslint-plugin-misc) - Miscellaneous rules including rules for creating custom checks and wrapping (modifying) third-party rules.
+- [no-spanish](https://github.com/Nicolasramos411/eslint-plugin-no-spanish) - Flags Spanish comments and Spanish variable/function/class names to keep a JS/TS codebase in English.
 - [Notice](https://github.com/nickdeis/eslint-plugin-notice) - An eslint rule that checks the top of files and fixes them too!
 - [Only-Error](https://github.com/davidjbradshaw/eslint-plugin-only-error) - Convert all rules to errors.
 - [Only-Warn](https://github.com/bfanger/eslint-plugin-only-warn) - Convert all rules to warnings.


### PR DESCRIPTION
Adds [eslint-plugin-no-spanish](https://github.com/Nicolasramos411/eslint-plugin-no-spanish), an ESLint plugin with two rules (`no-es-comment`, `no-es-identifier`) that flag Spanish comments and Spanish variable/function/class names to keep language usage consistent across a JS/TS codebase. Useful for teams with mixed-language contributors who want that drift caught automatically instead of in code review.

- Follows the `[Item Name](link) - Short Description` format
- Added alphabetically to the Misc category