### PR TITLE
Add silent-dto

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,6 +247,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 - [pii](https://github.com/shiva-hack/eslint-plugin-pii) - Checks and enforces PII Compliance of the code. i.e. no email address, birth date, IP address or phone number in comments or string literals.
 - [pg](https://github.com/interlace-collie/eslint/tree/main/packages/eslint-plugin-pg) - PostgreSQL/node-postgres security: SQL injection prevention (CWE-89), connection pool leak detection (CWE-772), transaction safety. 13 rules with CWE mapping.
 - [Security](https://github.com/nodesecurity/eslint-plugin-security) - ESLint rules for Node Security.
+- [silent-dto](https://github.com/DevyanshuNegi/silent-dto) - Finds NestJS `@Body()` parameters where ValidationPipe silently skips validation.
 - [xss](https://github.com/Rantanen/eslint-plugin-xss) - Tries to detect XSS issues in codebase before they end up in production.
 
 ### Style


### PR DESCRIPTION
Adds [silent-dto](https://github.com/DevyanshuNegi/silent-dto) to the Security plugins section.

It finds NestJS `@Body()` parameters whose type annotation erases to `Object` at runtime (`Partial<T>`, `unknown`, inline literals, `import()` types), which makes the global ValidationPipe silently skip them — no whitelisting, no constraints. Ships as a flat-config ESLint rule plus an `npx` audit CLI, on [npm](https://www.npmjs.com/package/silent-dto).

Placed alphabetically in Security (the practical impact is unvalidated input / mass assignment). I'm the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)